### PR TITLE
Fix instructor file path

### DIFF
--- a/src/su_solarnorth/generic_tool.rb
+++ b/src/su_solarnorth/generic_tool.rb
@@ -104,7 +104,7 @@ module Trimble
 
       # @see https://ruby.sketchup.com/Sketchup/Tool.html
       def getInstructorContentDirectory
-        "su_solarnorth/instructors/#{self.class.tool_id}.html"
+        "#{EXTENSION_ROOT}/instructors/#{self.class.tool_id}.html"
       end
     end
   end


### PR DESCRIPTION
I broke this earlier when changing the Ruby require paths to not be absolute paths.